### PR TITLE
Fix use case error typo

### DIFF
--- a/libs/core/src/errors/error-code.enum.ts
+++ b/libs/core/src/errors/error-code.enum.ts
@@ -4,5 +4,5 @@ export enum DomainErrorCode {
 
 export enum UseCaseErrorCode {
     NOT_FOUND = 20000,
-    VALICATION_ERROR = 20001,
+    VALIDATION_ERROR = 20001,
 }


### PR DESCRIPTION
## Summary
- fix typo in `UseCaseErrorCode` enum

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862b69b76b48325baad39d6832d3d33